### PR TITLE
feat: add buildDocs for shipping package docs to AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,30 @@ async function compile() {
   });
 }
 ```
+
+## buildDocs
+
+Generates a documentation tree for AI agents from a package's markdown sources
+(component/hook READMEs plus any markdown under `docs/`), cleaned of Storybook /
+GitHub service markers, badges and images. The output ships inside the npm
+tarball so an agent working in a consumer project reads documentation matching
+the installed version, discoverable via a generated `INDEX.md`.
+
+`buildDocs` is a plain function (not a gulp plugin), so it works from any build
+pipeline — call it from a gulp task, an npm script, or a rollup hook.
+
+```ts
+import {buildDocs, standardDocsConfig} from '@gravity-ui/gulp-utils';
+
+const {name} = require('./package.json');
+
+// standardDocsConfig covers the shared gravity-ui layout:
+//   docs/**/*.md            → build/docs/guides/
+//   src/components/*/README  → build/docs/components/   (legacy/ excluded)
+//   src/hooks/*/README       → build/docs/hooks/        (private/ excluded)
+buildDocs(standardDocsConfig(process.cwd(), name));
+```
+
+Pass a custom `DocsConfig` to change the sources, output directory or INDEX
+section order. Intra-repo `README.md` links are rewritten to resolve inside the
+output; links to docs that aren't shipped are unwrapped to plain text.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ import {buildDocs, standardDocsConfig} from '@gravity-ui/gulp-utils';
 //   docs/**/*.md            → build/docs/guides/
 //   src/components/*/README  → build/docs/components/   (legacy/ excluded)
 //   src/hooks/*/README       → build/docs/hooks/        (private/ excluded)
-buildDocs(standardDocsConfig(process.cwd()));
+buildDocs(standardDocsConfig());
 ```
 
-The package name shown in the generated `INDEX.md` is read from the consumer's
-`package.json` by default; pass it explicitly as the second argument to override.
+`rootDir` defaults to `process.cwd()`, and the package name shown in the
+generated `INDEX.md` is read from that `package.json` — pass them explicitly
+(`standardDocsConfig(rootDir, packageName)`) to override.
 Pass a custom `DocsConfig` to change the sources, output directory or INDEX
 section order. Intra-repo `README.md` links are rewritten to resolve inside the
 output; links to docs that aren't shipped are unwrapped to plain text.

--- a/README.md
+++ b/README.md
@@ -53,18 +53,19 @@ the installed version, discoverable via a generated `INDEX.md`.
 pipeline — call it from a gulp task, an npm script, or a rollup hook.
 
 ```ts
-import {buildDocs, standardDocsConfig} from '@gravity-ui/gulp-utils';
+import {buildDocs, createDefaultDocsConfig} from '@gravity-ui/gulp-utils';
 
-// standardDocsConfig covers the shared gravity-ui layout:
+// buildDocs() with no config uses createDefaultDocsConfig(), the shared
+// gravity-ui layout:
 //   docs/**/*.md            → build/docs/guides/
 //   src/components/*/README  → build/docs/components/   (legacy/ excluded)
 //   src/hooks/*/README       → build/docs/hooks/        (private/ excluded)
-buildDocs(standardDocsConfig());
+buildDocs();
 ```
 
 `rootDir` defaults to `process.cwd()`, and the package name shown in the
 generated `INDEX.md` is read from that `package.json` — pass them explicitly
-(`standardDocsConfig(rootDir, packageName)`) to override.
+(`createDefaultDocsConfig(rootDir, packageName)`) to override.
 Pass a custom `DocsConfig` to change the sources, output directory or INDEX
 section order. Intra-repo `README.md` links are rewritten to resolve inside the
 output; links to docs that aren't shipped are unwrapped to plain text.

--- a/README.md
+++ b/README.md
@@ -55,15 +55,15 @@ pipeline — call it from a gulp task, an npm script, or a rollup hook.
 ```ts
 import {buildDocs, standardDocsConfig} from '@gravity-ui/gulp-utils';
 
-const {name} = require('./package.json');
-
 // standardDocsConfig covers the shared gravity-ui layout:
 //   docs/**/*.md            → build/docs/guides/
 //   src/components/*/README  → build/docs/components/   (legacy/ excluded)
 //   src/hooks/*/README       → build/docs/hooks/        (private/ excluded)
-buildDocs(standardDocsConfig(process.cwd(), name));
+buildDocs(standardDocsConfig(process.cwd()));
 ```
 
+The package name shown in the generated `INDEX.md` is read from the consumer's
+`package.json` by default; pass it explicitly as the second argument to override.
 Pass a custom `DocsConfig` to change the sources, output directory or INDEX
 section order. Intra-repo `README.md` links are rewritten to resolve inside the
 output; links to docs that aren't shipped are unwrapped to plain text.

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -1,0 +1,269 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {cleanMarkdown, extractSummary, extractTitle} from './cleanMarkdown.js';
+
+// Story/test folders hold Storybook doc pages and fixtures, not API docs.
+const DEFAULT_EXCLUDE = ['__stories__', '__tests__', '__mocks__', '__snapshots__'];
+
+export type DocsSourceKind = 'readme' | 'markdown';
+
+export interface DocsSource {
+    /** Section heading in the generated INDEX.md. */
+    title: string;
+    /** `readme` walks for README.md files; `markdown` takes every *.md. */
+    kind: DocsSourceKind;
+    /** Source directory, relative to `rootDir`. */
+    baseDir: string;
+    /** Output subdirectory under `outDir`. */
+    outPrefix: string;
+    /** Directory names to skip (in addition to story/test folders). */
+    exclude?: string[];
+    /** Name the index entry by the doc's heading instead of its path. */
+    nameFromTitle?: boolean;
+}
+
+export interface DocsConfig {
+    /** Repo root. */
+    rootDir: string;
+    /** Directory to (re)generate. */
+    outDir: string;
+    /** Shown in the generated INDEX.md header. */
+    packageName: string;
+    /** Doc sources; INDEX sections follow this order. */
+    sources: DocsSource[];
+}
+
+export interface DocsIndexEntry {
+    name: string;
+    rel: string;
+    summary: string;
+}
+
+export interface DocsSection {
+    title: string;
+    entries: DocsIndexEntry[];
+}
+
+export interface BuildDocsResult {
+    sections: DocsSection[];
+    total: number;
+}
+
+interface DocItem {
+    source: string;
+    name: string;
+    outRel: string;
+}
+
+/**
+ * The layout shared by gravity-ui packages: component and hook READMEs plus any
+ * markdown dropped under the repo-level `docs/` folder. `exclude: ['legacy']`
+ * and an empty `docs/` are both harmless when a package lacks them, so the same
+ * config drives every package (uikit, navigation, …).
+ */
+export function standardDocsConfig(rootDir: string, packageName: string): DocsConfig {
+    return {
+        rootDir,
+        packageName,
+        outDir: path.join(rootDir, 'build', 'docs'),
+        sources: [
+            {
+                title: 'Guides',
+                kind: 'markdown',
+                baseDir: 'docs',
+                outPrefix: 'guides',
+                nameFromTitle: true,
+            },
+            {
+                title: 'Components',
+                kind: 'readme',
+                baseDir: 'src/components',
+                outPrefix: 'components',
+                exclude: ['legacy'],
+            },
+            {
+                title: 'Hooks',
+                kind: 'readme',
+                baseDir: 'src/hooks',
+                outPrefix: 'hooks',
+                exclude: ['private'],
+            },
+        ],
+    };
+}
+
+/**
+ * Builds a package's docs output for AI agents from its markdown sources.
+ * The output ships inside the npm tarball so an agent working in a consumer
+ * project reads documentation matching the installed version. Usually called
+ * with {@link standardDocsConfig}.
+ */
+export function buildDocs(config: DocsConfig): BuildDocsResult {
+    const {rootDir, outDir, packageName, sources} = config;
+
+    fs.rmSync(outDir, {recursive: true, force: true});
+
+    // Resolve every source's items first, so links between docs can be rewritten
+    // in the second pass regardless of processing order.
+    const listed = sources.map((source) => ({source, items: listSource(rootDir, source)}));
+    const docMap = new Map(listed.flatMap(({items}) => items.map((it) => [it.source, it.outRel])));
+
+    const sections: DocsSection[] = [];
+    for (const {source, items} of listed) {
+        const entries: DocsIndexEntry[] = [];
+        for (const {source: file, name, outRel} of items) {
+            const cleaned = rewriteReadmeLinks(
+                cleanMarkdown(fs.readFileSync(file, 'utf8')),
+                file,
+                outRel,
+                docMap,
+            );
+            writeDoc(path.join(outDir, outRel), cleaned);
+            entries.push({
+                name: source.nameFromTitle ? extractTitle(cleaned) || name : name,
+                rel: outRel,
+                summary: extractSummary(cleaned),
+            });
+        }
+        sections.push({title: source.title, entries});
+    }
+
+    const outRelToRoot = path.relative(rootDir, outDir).split(path.sep).join('/');
+    writeDoc(path.join(outDir, 'INDEX.md'), renderIndex(packageName, outRelToRoot, sections));
+
+    const total = sections.reduce((sum, section) => sum + section.entries.length, 0);
+    return {sections, total};
+}
+
+/** Recursively collects `README.md` files under `dir`, skipping excluded segments. */
+function findReadmes(dir: string, exclude: string[] = []): string[] {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    const skip = new Set([...DEFAULT_EXCLUDE, ...exclude]);
+    const result: string[] = [];
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (skip.has(entry.name)) {
+                continue;
+            }
+            result.push(...findReadmes(fullPath, exclude));
+        } else if (/^readme\.md$/i.test(entry.name)) {
+            // Case-insensitive: some packages use `Readme.md` (e.g. navigation).
+            result.push(fullPath);
+        }
+    }
+    return result;
+}
+
+/** Recursively collects `*.md` files under `dir`. */
+function findMarkdown(dir: string): string[] {
+    if (!fs.existsSync(dir)) {
+        return [];
+    }
+    const result: string[] = [];
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            result.push(...findMarkdown(fullPath));
+        } else if (entry.name.endsWith('.md')) {
+            result.push(fullPath);
+        }
+    }
+    return result;
+}
+
+function writeDoc(outPath: string, content: string): void {
+    fs.mkdirSync(path.dirname(outPath), {recursive: true});
+    fs.writeFileSync(outPath, content);
+}
+
+/**
+ * Lists a source's docs as items, mirroring the source folder layout so nested
+ * groups never collide (e.g. `src/components/controls/TextInput/README.md` →
+ * `components/controls/TextInput.md`, `docs/theming.md` → `guides/theming.md`).
+ */
+function listSource(rootDir: string, {kind, baseDir, outPrefix, exclude}: DocsSource): DocItem[] {
+    const absBase = path.join(rootDir, baseDir);
+    if (kind === 'readme') {
+        return findReadmes(absBase, exclude).map((source) => {
+            const name = path.relative(absBase, path.dirname(source)).split(path.sep).join('/');
+            return {source, name, outRel: path.posix.join(outPrefix, `${name}.md`)};
+        });
+    }
+    return findMarkdown(absBase).map((source) => {
+        const rel = path.relative(absBase, source).split(path.sep).join('/');
+        return {source, name: rel.replace(/\.md$/, ''), outRel: path.posix.join(outPrefix, rel)};
+    });
+}
+
+/**
+ * Rewrites intra-repo `README.md` links so they resolve inside the docs output.
+ * Source links point at sibling source folders (`../CopyToClipboard/README.md`);
+ * here every README maps to a flat `<name>.md`, so links are recomputed relative
+ * to the current output file. Links to docs that aren't shipped (e.g. `legacy/`)
+ * are unwrapped to plain text so no dead link remains. External URLs are kept.
+ */
+function rewriteReadmeLinks(
+    markdown: string,
+    source: string,
+    outRel: string,
+    docMap: Map<string, string>,
+): string {
+    return markdown.replace(/\[([^\]]*)\]\(([^)]+)\)/g, (whole, text: string, target: string) => {
+        if (!/readme\.md/i.test(target)) {
+            return whole;
+        }
+        if (/^[a-z]+:\/\//i.test(target)) {
+            return whole; // external URL — leave as-is
+        }
+
+        const hashIndex = target.indexOf('#');
+        const relPath = hashIndex === -1 ? target : target.slice(0, hashIndex);
+        const anchor = hashIndex === -1 ? '' : target.slice(hashIndex);
+
+        const absTarget = path.resolve(path.dirname(source), relPath);
+        const targetOut = docMap.get(absTarget);
+        if (!targetOut) {
+            return text; // target not shipped — drop the link, keep its text
+        }
+
+        let relOut = path.posix.relative(path.posix.dirname(outRel), targetOut);
+        if (!relOut.startsWith('.')) {
+            relOut = `./${relOut}`;
+        }
+        return `[${text}](${relOut}${anchor})`;
+    });
+}
+
+function renderSection(title: string, entries: DocsIndexEntry[]): string {
+    if (!entries.length) {
+        return '';
+    }
+    const rows = entries
+        .slice()
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map(({name, rel, summary}) => `- [${name}](./${rel})${summary ? ` — ${summary}` : ''}`)
+        .join('\n');
+    return `## ${title}\n\n${rows}\n`;
+}
+
+function renderIndex(packageName: string, outRelToRoot: string, sections: DocsSection[]): string {
+    // e.g. node_modules/@gravity-ui/uikit/build/docs
+    const installedPath = path.posix.join('node_modules', packageName, outRelToRoot);
+    const header = [
+        `# ${packageName} documentation`,
+        '',
+        `Documentation for the **installed** version of \`${packageName}\`.`,
+        'Your training data may be outdated — these files are the source of truth.',
+        '',
+        `Paths are relative to this file (\`${installedPath}/\`).`,
+        '',
+    ].join('\n');
+
+    return [header, ...sections.map(({title, entries}) => renderSection(title, entries))]
+        .filter(Boolean)
+        .join('\n');
+}

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -56,10 +56,16 @@ interface DocItem {
     outRel: string;
 }
 
-// The layout shared by gravity-ui packages: component and hook READMEs plus any
-// markdown dropped under the repo-level docs/ folder. `exclude: ['legacy']` and
-// an empty docs/ are both harmless when a package lacks them, so the same config
-// drives every package (uikit, navigation, …).
+/**
+ * Builds the config for the layout shared by gravity-ui packages: component and
+ * hook READMEs plus any markdown under the repo-level docs/ folder. `legacy/` and
+ * an empty docs/ are both harmless when a package lacks them, so the same config
+ * drives every package (uikit, navigation, …).
+ *
+ * @param rootDir repo root; defaults to `process.cwd()`.
+ * @param packageName INDEX.md header name; defaults to `rootDir`'s package name.
+ * @returns the docs config to pass to {@link buildDocs}.
+ */
 export function createDefaultDocsConfig(
     rootDir: string = process.cwd(),
     packageName?: string,
@@ -94,10 +100,14 @@ export function createDefaultDocsConfig(
     };
 }
 
-// Builds a package's docs output for AI agents from its markdown sources.
-// The output ships inside the npm tarball so an agent working in a consumer
-// project reads documentation matching the installed version. Usually called
-// with createDefaultDocsConfig().
+/**
+ * Builds a package's docs output for AI agents from its markdown sources. The
+ * output ships inside the npm tarball so an agent working in a consumer project
+ * reads documentation matching the installed version.
+ *
+ * @param config docs config; defaults to {@link createDefaultDocsConfig}().
+ * @returns the generated sections and the total document count.
+ */
 export function buildDocs(config: DocsConfig = createDefaultDocsConfig()): BuildDocsResult {
     const {outDir, sources} = config;
     const rootDir = config.rootDir ?? process.cwd();

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -62,7 +62,7 @@ interface DocItem {
  * and an empty `docs/` are both harmless when a package lacks them, so the same
  * config drives every package (uikit, navigation, …).
  */
-export function standardDocsConfig(
+export function createDefaultDocsConfig(
     rootDir: string = process.cwd(),
     packageName?: string,
 ): DocsConfig {
@@ -100,9 +100,9 @@ export function standardDocsConfig(
  * Builds a package's docs output for AI agents from its markdown sources.
  * The output ships inside the npm tarball so an agent working in a consumer
  * project reads documentation matching the installed version. Usually called
- * with {@link standardDocsConfig}.
+ * with {@link createDefaultDocsConfig}.
  */
-export function buildDocs(config: DocsConfig): BuildDocsResult {
+export function buildDocs(config: DocsConfig = createDefaultDocsConfig()): BuildDocsResult {
     const {outDir, sources} = config;
     const rootDir = config.rootDir ?? process.cwd();
     const packageName = config.packageName ?? readPackageName(rootDir);

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -24,8 +24,8 @@ export interface DocsSource {
 }
 
 export interface DocsConfig {
-    /** Repo root. */
-    rootDir: string;
+    /** Repo root. Defaults to `process.cwd()`. */
+    rootDir?: string;
     /** Directory to (re)generate. */
     outDir: string;
     /** Shown in the generated INDEX.md header. Defaults to `rootDir`'s package name. */
@@ -62,7 +62,10 @@ interface DocItem {
  * and an empty `docs/` are both harmless when a package lacks them, so the same
  * config drives every package (uikit, navigation, …).
  */
-export function standardDocsConfig(rootDir: string, packageName?: string): DocsConfig {
+export function standardDocsConfig(
+    rootDir: string = process.cwd(),
+    packageName?: string,
+): DocsConfig {
     return {
         rootDir,
         packageName: packageName ?? readPackageName(rootDir),
@@ -100,7 +103,8 @@ export function standardDocsConfig(rootDir: string, packageName?: string): DocsC
  * with {@link standardDocsConfig}.
  */
 export function buildDocs(config: DocsConfig): BuildDocsResult {
-    const {rootDir, outDir, sources} = config;
+    const {outDir, sources} = config;
+    const rootDir = config.rootDir ?? process.cwd();
     const packageName = config.packageName ?? readPackageName(rootDir);
 
     fs.rmSync(outDir, {recursive: true, force: true});

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -28,8 +28,8 @@ export interface DocsConfig {
     rootDir: string;
     /** Directory to (re)generate. */
     outDir: string;
-    /** Shown in the generated INDEX.md header. */
-    packageName: string;
+    /** Shown in the generated INDEX.md header. Defaults to `rootDir`'s package name. */
+    packageName?: string;
     /** Doc sources; INDEX sections follow this order. */
     sources: DocsSource[];
 }
@@ -62,10 +62,10 @@ interface DocItem {
  * and an empty `docs/` are both harmless when a package lacks them, so the same
  * config drives every package (uikit, navigation, …).
  */
-export function standardDocsConfig(rootDir: string, packageName: string): DocsConfig {
+export function standardDocsConfig(rootDir: string, packageName?: string): DocsConfig {
     return {
         rootDir,
-        packageName,
+        packageName: packageName ?? readPackageName(rootDir),
         outDir: path.join(rootDir, 'build', 'docs'),
         sources: [
             {
@@ -100,7 +100,8 @@ export function standardDocsConfig(rootDir: string, packageName: string): DocsCo
  * with {@link standardDocsConfig}.
  */
 export function buildDocs(config: DocsConfig): BuildDocsResult {
-    const {rootDir, outDir, packageName, sources} = config;
+    const {rootDir, outDir, sources} = config;
+    const packageName = config.packageName ?? readPackageName(rootDir);
 
     fs.rmSync(outDir, {recursive: true, force: true});
 
@@ -173,6 +174,13 @@ function findMarkdown(dir: string): string[] {
         }
     }
     return result;
+}
+
+function readPackageName(rootDir: string): string {
+    const pkg = JSON.parse(fs.readFileSync(path.join(rootDir, 'package.json'), 'utf8')) as {
+        name?: string;
+    };
+    return pkg.name ?? '';
 }
 
 function writeDoc(outPath: string, content: string): void {

--- a/src/buildDocs.ts
+++ b/src/buildDocs.ts
@@ -56,12 +56,10 @@ interface DocItem {
     outRel: string;
 }
 
-/**
- * The layout shared by gravity-ui packages: component and hook READMEs plus any
- * markdown dropped under the repo-level `docs/` folder. `exclude: ['legacy']`
- * and an empty `docs/` are both harmless when a package lacks them, so the same
- * config drives every package (uikit, navigation, …).
- */
+// The layout shared by gravity-ui packages: component and hook READMEs plus any
+// markdown dropped under the repo-level docs/ folder. `exclude: ['legacy']` and
+// an empty docs/ are both harmless when a package lacks them, so the same config
+// drives every package (uikit, navigation, …).
 export function createDefaultDocsConfig(
     rootDir: string = process.cwd(),
     packageName?: string,
@@ -96,12 +94,10 @@ export function createDefaultDocsConfig(
     };
 }
 
-/**
- * Builds a package's docs output for AI agents from its markdown sources.
- * The output ships inside the npm tarball so an agent working in a consumer
- * project reads documentation matching the installed version. Usually called
- * with {@link createDefaultDocsConfig}.
- */
+// Builds a package's docs output for AI agents from its markdown sources.
+// The output ships inside the npm tarball so an agent working in a consumer
+// project reads documentation matching the installed version. Usually called
+// with createDefaultDocsConfig().
 export function buildDocs(config: DocsConfig = createDefaultDocsConfig()): BuildDocsResult {
     const {outDir, sources} = config;
     const rootDir = config.rootDir ?? process.cwd();
@@ -141,7 +137,7 @@ export function buildDocs(config: DocsConfig = createDefaultDocsConfig()): Build
     return {sections, total};
 }
 
-/** Recursively collects `README.md` files under `dir`, skipping excluded segments. */
+// Recursively collects README.md files under `dir`, skipping excluded segments.
 function findReadmes(dir: string, exclude: string[] = []): string[] {
     if (!fs.existsSync(dir)) {
         return [];
@@ -163,7 +159,7 @@ function findReadmes(dir: string, exclude: string[] = []): string[] {
     return result;
 }
 
-/** Recursively collects `*.md` files under `dir`. */
+// Recursively collects *.md files under `dir`.
 function findMarkdown(dir: string): string[] {
     if (!fs.existsSync(dir)) {
         return [];
@@ -192,11 +188,9 @@ function writeDoc(outPath: string, content: string): void {
     fs.writeFileSync(outPath, content);
 }
 
-/**
- * Lists a source's docs as items, mirroring the source folder layout so nested
- * groups never collide (e.g. `src/components/controls/TextInput/README.md` →
- * `components/controls/TextInput.md`, `docs/theming.md` → `guides/theming.md`).
- */
+// Lists a source's docs as items, mirroring the source folder layout so nested
+// groups never collide (e.g. src/components/controls/TextInput/README.md →
+// components/controls/TextInput.md, docs/theming.md → guides/theming.md).
 function listSource(rootDir: string, {kind, baseDir, outPrefix, exclude}: DocsSource): DocItem[] {
     const absBase = path.join(rootDir, baseDir);
     if (kind === 'readme') {
@@ -211,13 +205,11 @@ function listSource(rootDir: string, {kind, baseDir, outPrefix, exclude}: DocsSo
     });
 }
 
-/**
- * Rewrites intra-repo `README.md` links so they resolve inside the docs output.
- * Source links point at sibling source folders (`../CopyToClipboard/README.md`);
- * here every README maps to a flat `<name>.md`, so links are recomputed relative
- * to the current output file. Links to docs that aren't shipped (e.g. `legacy/`)
- * are unwrapped to plain text so no dead link remains. External URLs are kept.
- */
+// Rewrites intra-repo README.md links so they resolve inside the docs output.
+// Source links point at sibling source folders (../CopyToClipboard/README.md);
+// here every README maps to a flat <name>.md, so links are recomputed relative
+// to the current output file. Links to docs that aren't shipped (e.g. legacy/)
+// are unwrapped to plain text so no dead link remains. External URLs are kept.
 function rewriteReadmeLinks(
     markdown: string,
     source: string,

--- a/src/cleanMarkdown.ts
+++ b/src/cleanMarkdown.ts
@@ -1,17 +1,15 @@
-/**
- * Prepares a source README for shipping inside the npm tarball (e.g. `build/docs/`),
- * where it is consumed by AI agents rather than rendered on GitHub or Storybook.
- *
- * gravity-ui docs sources use a few service markers:
- *   - `<!--SANDBOX ... SANDBOX-->`               commented-out interactive Storybook code
- *   - `<!--LANDING_BLOCK ... LANDING_BLOCK-->`    commented-out content for the landing site
- *   - `<!--GITHUB_BLOCK-->` / `<!--/GITHUB_BLOCK-->`   wrappers around GitHub-only content
- *
- * SANDBOX/LANDING blocks are commented out (their code duplicates the plain
- * fenced example shown right after), so they are dropped entirely. GITHUB_BLOCK
- * markers wrap real content we want to keep — only the marker lines are removed.
- * Badges and images carry no value for an agent and are stripped too.
- */
+// Prepares a source README for shipping inside the npm tarball (e.g. build/docs/),
+// where it is consumed by AI agents rather than rendered on GitHub or Storybook.
+//
+// gravity-ui docs sources use a few service markers:
+//   - <!--SANDBOX ... SANDBOX-->                    commented-out interactive Storybook code
+//   - <!--LANDING_BLOCK ... LANDING_BLOCK-->         commented-out content for the landing site
+//   - <!--GITHUB_BLOCK--> / <!--/GITHUB_BLOCK-->     wrappers around GitHub-only content
+//
+// SANDBOX/LANDING blocks are commented out (their code duplicates the plain
+// fenced example shown right after), so they are dropped entirely. GITHUB_BLOCK
+// markers wrap real content we want to keep — only the marker lines are removed.
+// Badges and images carry no value for an agent and are stripped too.
 export function cleanMarkdown(content: string): string {
     let text = content.replace(/\r\n/g, '\n');
 
@@ -39,13 +37,11 @@ export function cleanMarkdown(content: string): string {
     return `${text.trim()}\n`;
 }
 
-/**
- * Extracts a one-line summary for the docs index. By convention a README opens
- * with the title, the import example, then a description line — so the summary
- * is the first prose line after the title, skipping the leading code block.
- * If a section heading follows the title directly (the file doesn't yet follow
- * the convention), there is no intro paragraph and the summary is empty.
- */
+// Extracts a one-line summary for the docs index. By convention a README opens
+// with the title, the import example, then a description line — so the summary
+// is the first prose line after the title, skipping the leading code block.
+// If a section heading follows the title directly (the file doesn't yet follow
+// the convention), there is no intro paragraph and the summary is empty.
 export function extractSummary(cleanedMarkdown: string, maxLength = 300): string {
     const lines = cleanedMarkdown.split('\n');
 
@@ -82,7 +78,7 @@ export function extractSummary(cleanedMarkdown: string, maxLength = 300): string
     return '';
 }
 
-/** Returns the text of the first heading, or '' if there is none. */
+// Returns the text of the first heading, or '' if there is none.
 export function extractTitle(cleanedMarkdown: string): string {
     for (const line of cleanedMarkdown.split('\n')) {
         const match = line.trim().match(/^#{1,6}\s+(.+)$/);

--- a/src/cleanMarkdown.ts
+++ b/src/cleanMarkdown.ts
@@ -1,0 +1,106 @@
+/**
+ * Prepares a source README for shipping inside the npm tarball (e.g. `build/docs/`),
+ * where it is consumed by AI agents rather than rendered on GitHub or Storybook.
+ *
+ * gravity-ui docs sources use a few service markers:
+ *   - `<!--SANDBOX ... SANDBOX-->`               commented-out interactive Storybook code
+ *   - `<!--LANDING_BLOCK ... LANDING_BLOCK-->`    commented-out content for the landing site
+ *   - `<!--GITHUB_BLOCK-->` / `<!--/GITHUB_BLOCK-->`   wrappers around GitHub-only content
+ *
+ * SANDBOX/LANDING blocks are commented out (their code duplicates the plain
+ * fenced example shown right after), so they are dropped entirely. GITHUB_BLOCK
+ * markers wrap real content we want to keep — only the marker lines are removed.
+ * Badges and images carry no value for an agent and are stripped too.
+ */
+export function cleanMarkdown(content: string): string {
+    let text = content.replace(/\r\n/g, '\n');
+
+    // Drop commented-out blocks whole (open + body + close).
+    text = text.replace(/<!--SANDBOX[\s\S]*?SANDBOX-->/g, '');
+    text = text.replace(/<!--LANDING_BLOCK[\s\S]*?LANDING_BLOCK-->/g, '');
+
+    // Keep GitHub-only content, remove just the wrapper markers.
+    text = text.replace(/<!--\/?GITHUB_BLOCK-->/g, '');
+
+    // Any remaining standalone HTML comments have no value for an agent.
+    text = text.replace(/<!--[\s\S]*?-->/g, '');
+
+    // Standalone image / badge lines (shields.io etc.).
+    text = text.replace(/^[ \t]*!\[[^\]]*\]\([^)]*\)[ \t]*$/gm, '');
+    // Inline images inside headings/links, e.g. `### ![logo](x) [Website](url)`.
+    text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, '');
+
+    // Trailing whitespace left behind by the removals.
+    text = text.replace(/[ \t]+$/gm, '');
+
+    // Collapse the blank-line runs the removals produced.
+    text = text.replace(/\n{3,}/g, '\n\n');
+
+    return `${text.trim()}\n`;
+}
+
+/**
+ * Extracts a one-line summary for the docs index. By convention a README opens
+ * with the title, the import example, then a description line — so the summary
+ * is the first prose line after the title, skipping the leading code block.
+ * If a section heading follows the title directly (the file doesn't yet follow
+ * the convention), there is no intro paragraph and the summary is empty.
+ */
+export function extractSummary(cleanedMarkdown: string, maxLength = 300): string {
+    const lines = cleanedMarkdown.split('\n');
+
+    // Anchor on the title (first heading), then read what comes after it.
+    const titleIndex = lines.findIndex((line) => /^#{1,6}\s+/.test(line.trim()));
+    if (titleIndex === -1) {
+        return '';
+    }
+
+    for (let i = titleIndex + 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+
+        if (!line) {
+            continue;
+        }
+        // Skip the leading import/example code block.
+        if (line.startsWith('```')) {
+            i++;
+            while (i < lines.length && !lines[i].trim().startsWith('```')) {
+                i++;
+            }
+            continue;
+        }
+        // A heading right after the title means there is no intro paragraph.
+        if (line.startsWith('#')) {
+            return '';
+        }
+
+        // Unwrap links to plain text — the index line has its own base path.
+        const plain = line.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1').replace(/[*_`]/g, '');
+        return truncate(plain, maxLength);
+    }
+
+    return '';
+}
+
+/** Returns the text of the first heading, or '' if there is none. */
+export function extractTitle(cleanedMarkdown: string): string {
+    for (const line of cleanedMarkdown.split('\n')) {
+        const match = line.trim().match(/^#{1,6}\s+(.+)$/);
+        if (match) {
+            return match[1].replace(/[*_`]/g, '').trim();
+        }
+    }
+    return '';
+}
+
+function truncate(text: string, maxLength: number): string {
+    if (text.length <= maxLength) {
+        return text;
+    }
+    const sentenceEnd = text.slice(0, maxLength).lastIndexOf('. ');
+    if (sentenceEnd > 40) {
+        return text.slice(0, sentenceEnd + 1);
+    }
+    const wordEnd = text.slice(0, maxLength).lastIndexOf(' ');
+    return `${text.slice(0, wordEnd > 40 ? wordEnd : maxLength).trim()}…`;
+}

--- a/src/cleanMarkdown.ts
+++ b/src/cleanMarkdown.ts
@@ -1,15 +1,14 @@
-// Prepares a source README for shipping inside the npm tarball (e.g. build/docs/),
-// where it is consumed by AI agents rather than rendered on GitHub or Storybook.
-//
-// gravity-ui docs sources use a few service markers:
-//   - <!--SANDBOX ... SANDBOX-->                    commented-out interactive Storybook code
-//   - <!--LANDING_BLOCK ... LANDING_BLOCK-->         commented-out content for the landing site
-//   - <!--GITHUB_BLOCK--> / <!--/GITHUB_BLOCK-->     wrappers around GitHub-only content
-//
-// SANDBOX/LANDING blocks are commented out (their code duplicates the plain
-// fenced example shown right after), so they are dropped entirely. GITHUB_BLOCK
-// markers wrap real content we want to keep — only the marker lines are removed.
-// Badges and images carry no value for an agent and are stripped too.
+/**
+ * Prepares a source README for shipping inside the npm tarball (e.g. build/docs/),
+ * where it is consumed by AI agents rather than rendered on GitHub or Storybook.
+ *
+ * Commented-out `SANDBOX`/`LANDING_BLOCK` markers (their code duplicates the plain
+ * fenced example shown right after) are dropped entirely; `GITHUB_BLOCK` wrappers
+ * are unwrapped, keeping their content. Badges and images are stripped.
+ *
+ * @param content raw markdown source.
+ * @returns the cleaned markdown, terminated by a single newline.
+ */
 export function cleanMarkdown(content: string): string {
     let text = content.replace(/\r\n/g, '\n');
 
@@ -37,11 +36,15 @@ export function cleanMarkdown(content: string): string {
     return `${text.trim()}\n`;
 }
 
-// Extracts a one-line summary for the docs index. By convention a README opens
-// with the title, the import example, then a description line — so the summary
-// is the first prose line after the title, skipping the leading code block.
-// If a section heading follows the title directly (the file doesn't yet follow
-// the convention), there is no intro paragraph and the summary is empty.
+/**
+ * Extracts a one-line summary for the docs index: the first prose line after the
+ * title, skipping the leading import/example code block. Returns an empty string
+ * when a section heading follows the title directly (no intro paragraph).
+ *
+ * @param cleanedMarkdown markdown already processed by {@link cleanMarkdown}.
+ * @param maxLength maximum summary length before it is truncated.
+ * @returns the summary line, or an empty string.
+ */
 export function extractSummary(cleanedMarkdown: string, maxLength = 300): string {
     const lines = cleanedMarkdown.split('\n');
 
@@ -78,7 +81,12 @@ export function extractSummary(cleanedMarkdown: string, maxLength = 300): string
     return '';
 }
 
-// Returns the text of the first heading, or '' if there is none.
+/**
+ * Extracts the document title.
+ *
+ * @param cleanedMarkdown markdown already processed by {@link cleanMarkdown}.
+ * @returns the text of the first heading, or an empty string if there is none.
+ */
 export function extractTitle(cleanedMarkdown: string): string {
     for (const line of cleanedMarkdown.split('\n')) {
         const match = line.trim().match(/^#{1,6}\s+(.+)$/);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,12 @@
 export {addVirtualFile} from './addVirtualFile.js';
 export {createTypescriptProject} from './createTypescriptProject.js';
+export {buildDocs, standardDocsConfig} from './buildDocs.js';
+export type {
+    DocsConfig,
+    DocsSource,
+    DocsSourceKind,
+    DocsSection,
+    DocsIndexEntry,
+    BuildDocsResult,
+} from './buildDocs.js';
+export {cleanMarkdown, extractSummary, extractTitle} from './cleanMarkdown.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export {addVirtualFile} from './addVirtualFile.js';
 export {createTypescriptProject} from './createTypescriptProject.js';
-export {buildDocs, standardDocsConfig} from './buildDocs.js';
+export {buildDocs, createDefaultDocsConfig} from './buildDocs.js';
 export type {
     DocsConfig,
     DocsSource,


### PR DESCRIPTION
## What

Adds `buildDocs(config)` and `standardDocsConfig(rootDir, packageName)` — a reusable generator that produces a documentation tree for AI agents from a package's markdown sources, so agents working in a consumer project can read docs matching the **installed** version (locally in `node_modules`, auto-versioned).

Extracted from a uikit pilot (gravity-ui/uikit#2740) so it can be shared across Tier-1 packages.

## API

- **`buildDocs(config)`** — cleans component/hook READMEs + any `docs/**/*.md`, writes them under a docs output dir, and generates an `INDEX.md` (name → one-line summary → path).
- **`standardDocsConfig(rootDir, packageName)`** — the shared gravity-ui layout:
  - `docs/**/*.md` → `build/docs/guides/`
  - `src/components/*/README.md` → `build/docs/components/` (`legacy/` excluded)
  - `src/hooks/*/README.md` → `build/docs/hooks/` (`private/` excluded)
- Also exports `cleanMarkdown` / `extractSummary` / `extractTitle`.

Cleaning strips Storybook/GitHub service markers (`<!--SANDBOX-->`, `<!--LANDING_BLOCK-->`, `<!--GITHUB_BLOCK-->`), badges and images. Intra-repo `README.md` links are rewritten to resolve inside the output; links to docs that aren't shipped (e.g. `legacy/`) are unwrapped to plain text.

## Design notes

- **Not a gulp plugin** — `buildDocs` is a plain function so it works from any build pipeline (gulp task, npm script, or a rollup project like `@gravity-ui/navigation` which doesn't use gulp). It lives here because this is the shared build-tooling package.
- **README matching is case-insensitive** (`README.md` / `Readme.md`) — navigation uses `Logo/Readme.md`.

## Verified

Built the `dist/` (tshy, ESM + CJS) and ran it against two real repos with the same `standardDocsConfig`:

| package | components | hooks |
| --- | --- | --- |
| `@gravity-ui/uikit` | 66 | 19 |
| `@gravity-ui/navigation` | 8 (incl. nested sub-component + `Logo/Readme.md`) | 1 |

`tsc --noEmit` clean; eslint clean (only the repo's pre-existing `valid-jsdoc` warnings, same as `createTypescriptProject.ts`).

## Follow-up

After release, `@gravity-ui/uikit` will replace its local `build-utils/build-docs.js` with a dependency on this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)